### PR TITLE
Enable transparency in image output.

### DIFF
--- a/SciAnalysis/CurveAnalysis/Data.py
+++ b/SciAnalysis/CurveAnalysis/Data.py
@@ -782,7 +782,7 @@ class DataLineStructuredSort(DataLineStructured):
         self._plot_extra(**plot_args)
         
         if save:
-            plt.savefig(save)
+            plt.savefig(save, transparent=True)
         
         if show:
             self._plot_interact()
@@ -1093,7 +1093,7 @@ class DataLineStructuredStd(DataLineStructured):
         self._plot_extra(**plot_args)
         
         if save:
-            plt.savefig(save)
+            plt.savefig(save, transparent=True)
         
         if show:
             self._plot_interact()
@@ -1323,7 +1323,7 @@ class DataLineStructuredFFT(DataLineStructured):
         self._plot_extra(**plot_args)
         
         if save:
-            plt.savefig(save)
+            plt.savefig(save, transparent=True)
         
         if show:
             self._plot_interact()

--- a/SciAnalysis/Data.py
+++ b/SciAnalysis/Data.py
@@ -414,9 +414,9 @@ class DataLine(object):
         
         if save:
             if 'dpi' in plot_args:
-                plt.savefig(save, dpi=plot_args['dpi'])
+                plt.savefig(save, dpi=plot_args['dpi'], transparent=True)
             else:
-                plt.savefig(save)
+                plt.savefig(save, transparent=True)
         
         if show:
             self._plot_interact()
@@ -436,7 +436,7 @@ class DataLine(object):
             l = plt.errorbar( self.x, self.y, xerr=self.x_err, yerr=self.y_err, **plot_args)
         
         else:
-            #l, = plt.plot(self.x, self.y, **plot_args)
+#            l, = plt.plot(self.x, self.y, **plot_args)
             l, = self.ax.plot(self.x, self.y, **plot_args)
             
             
@@ -709,9 +709,9 @@ class DataLineAngle (DataLine):
         
         if save:
             if 'dpi' in plot_args:
-                plt.savefig(save, dpi=plot_args['dpi'])
+                plt.savefig(save, dpi=plot_args['dpi'], transparent=True)
             else:
-                plt.savefig(save)
+                plt.savefig(save, transparent=True)
         
         if show:
             self._plot_interact()
@@ -907,9 +907,9 @@ class DataLinesStacked(DataLines):
         
         if save:
             if 'dpi' in plot_args:
-                plt.savefig(save, dpi=plot_args['dpi'])
+                plt.savefig(save, dpi=plot_args['dpi'], transparent=True)
             else:
-                plt.savefig(save)
+                plt.savefig(save, transparent=True)
         
         if show:
             self._plot_interact()
@@ -1632,9 +1632,9 @@ class Data2D(object):
         
         if save:
             if 'dpi' in plot_args:
-                plt.savefig(save, dpi=plot_args['dpi'])
+                plt.savefig(save, dpi=plot_args['dpi'], transparent=True)
             else:
-                plt.savefig(save)
+                plt.savefig(save, transparent=True)
         
         if show:
             self._plot_interact()

--- a/SciAnalysis/tools.py
+++ b/SciAnalysis/tools.py
@@ -192,9 +192,9 @@ class Processor(object):
             except OSError:
                 print('  ERROR (OSError) with file {}.'.format(infile))
 
-            #except Exception as exception:
-                # Ignore errors, so that execution doesn't get stuck on a single bad file
-                #print('  ERROR ({}) with file {}.'.format(exception.__class__.__name__, infile))
+            except Exception as exception:
+#                 Ignore errors, so that execution doesn't get stuck on a single bad file
+                print('  ERROR ({}) with file {}.'.format(exception.__class__.__name__, infile))
 
 
     def load(self, infile, **kwargs):


### PR DESCRIPTION
This is preferrable because .png is the default output format, which supports transparency. It's nicer to arrange images with transparency in Inkscape without having to deal with the white-background margins.